### PR TITLE
Move modclean-patterns-default to peer dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,11 +47,13 @@
     "empty-dir": "^1.0.0",
     "glob": "^7.1.2",
     "lodash.uniq": "^4.5.0",
-    "modclean-patterns-default": "latest",
     "ora": "^2.1.0",
     "progress": "^2.0.0",
     "rimraf": "^2.5.4",
     "subdirs": "^1.0.1"
+  },
+  "peerDependencies": {
+    "modclean-patterns-default": "latest"
   },
   "engines": {
     "node": ">=8.0.0"


### PR DESCRIPTION
This allows the user to use a specific version of modclean-patterns-default
instead of always using latest.