### PR TITLE
Fix default `emptyDirFilter`

### DIFF
--- a/lib/modclean.js
+++ b/lib/modclean.js
@@ -84,7 +84,7 @@ let defaults = {
      * @return {Boolean}      `true` if is a valid file, `false` if invalid file
      */
     emptyDirFilter: function(file) {
-        return !/(Thumbs\.db|\.DS_Store)$/i.test(file);
+        return /(Thumbs\.db|\.DS_Store)$/i.test(file);
     },
     /**
      * Custom options to pass into `glob` to further customize file searching. Will override existing options.


### PR DESCRIPTION
It looks as if you copied and pasted the default `emptyDirFilter` from [`empty-dir`'s own documentation](https://github.com/gulpjs/empty-dir/blob/45d1e0c/README.md#emptydirsyncpaths-filterfunction), which (at the time) was broken. A completely understandable error. I have [opened a PR](https://github.com/gulpjs/empty-dir/pull/9) to fix `empty-dir`'s documentation, but this usage must also be repaired. With its current behaviour, `modclean` considers *nearly every directory* to be empty and deletable by default, *except* those containing only garbage files.